### PR TITLE
style: apply clang-format to previously missed files

### DIFF
--- a/src/Cuda/benchmarks.cpp
+++ b/src/Cuda/benchmarks.cpp
@@ -945,9 +945,8 @@ void cudaSieveTestBenchmark(
     }
 
     for (int k = 0; k < 2; ++k) {
-        CUDA_SAFE_CALL(
-            sieveBuf[k].init(
-                mConfig.SIZE * mConfig.STRIPES / 2 * mConfig.WIDTH, false));
+        CUDA_SAFE_CALL(sieveBuf[k].init(
+            mConfig.SIZE * mConfig.STRIPES / 2 * mConfig.WIDTH, false));
         CUDA_SAFE_CALL(sieveOff[k].init(mConfig.PCOUNT * mConfig.WIDTH, false));
     }
 

--- a/src/Cuda/xpmclient.cpp
+++ b/src/Cuda/xpmclient.cpp
@@ -384,16 +384,14 @@ void PrimeMiner::Mining(GetBlockTemplateContext* gbp, SubmitContext* submit) {
                     sieveBuffers[sieveIdx][pipelineIdx][instIdx].init(
                         MSO, true));
 
-            CUDA_SAFE_CALL(
-                candidatesCountBuffers[sieveIdx][instIdx].init(
-                    FERMAT_PIPELINES, false)); // CL_MEM_ALLOC_HOST_PTR
+            CUDA_SAFE_CALL(candidatesCountBuffers[sieveIdx][instIdx].init(
+                FERMAT_PIPELINES, false)); // CL_MEM_ALLOC_HOST_PTR
         }
     }
 
     for (int k = 0; k < 2; ++k) {
-        CUDA_SAFE_CALL(
-            sieveBuf[k].init(
-                mConfig.SIZE * mConfig.STRIPES / 2 * mConfig.WIDTH, true));
+        CUDA_SAFE_CALL(sieveBuf[k].init(
+            mConfig.SIZE * mConfig.STRIPES / 2 * mConfig.WIDTH, true));
         CUDA_SAFE_CALL(sieveOff[k].init(mConfig.PCOUNT * mConfig.WIDTH, true));
     }
 

--- a/src/Hip/benchmarks_hip.cpp
+++ b/src/Hip/benchmarks_hip.cpp
@@ -1128,9 +1128,8 @@ void hipSieveTestBenchmark(
     }
 
     for (int k = 0; k < 2; ++k) {
-        HIP_SAFE_CALL(
-            sieveBuf[k].init(
-                mConfig.SIZE * mConfig.STRIPES / 2 * mConfig.WIDTH, false));
+        HIP_SAFE_CALL(sieveBuf[k].init(
+            mConfig.SIZE * mConfig.STRIPES / 2 * mConfig.WIDTH, false));
         HIP_SAFE_CALL(sieveOff[k].init(mConfig.PCOUNT * mConfig.WIDTH, false));
     }
 

--- a/src/Hip/xpmclient_hip.cpp
+++ b/src/Hip/xpmclient_hip.cpp
@@ -395,20 +395,17 @@ void PrimeMiner::Mining(GetBlockTemplateContext* gbp, SubmitContext* submit) {
         for (int instIdx = 0; instIdx < 2; ++instIdx) {
             for (int pipelineIdx = 0; pipelineIdx < FERMAT_PIPELINES;
                  pipelineIdx++)
-                HIP_SAFE_CALL(
-                    sieveBuffers[sieveIdx][pipelineIdx][instIdx].init(
-                        MSO, true));
+                HIP_SAFE_CALL(sieveBuffers[sieveIdx][pipelineIdx][instIdx].init(
+                    MSO, true));
 
-            HIP_SAFE_CALL(
-                candidatesCountBuffers[sieveIdx][instIdx].init(
-                    FERMAT_PIPELINES, false)); // CL_MEM_ALLOC_HOST_PTR
+            HIP_SAFE_CALL(candidatesCountBuffers[sieveIdx][instIdx].init(
+                FERMAT_PIPELINES, false)); // CL_MEM_ALLOC_HOST_PTR
         }
     }
 
     for (int k = 0; k < 2; ++k) {
-        HIP_SAFE_CALL(
-            sieveBuf[k].init(
-                mConfig.SIZE * mConfig.STRIPES / 2 * mConfig.WIDTH, true));
+        HIP_SAFE_CALL(sieveBuf[k].init(
+            mConfig.SIZE * mConfig.STRIPES / 2 * mConfig.WIDTH, true));
         HIP_SAFE_CALL(sieveOff[k].init(mConfig.PCOUNT * mConfig.WIDTH, true));
     }
 

--- a/src/OpenCL/sha256.h
+++ b/src/OpenCL/sha256.h
@@ -600,8 +600,9 @@ void SHA256_fresh(
 }
 
 void sha256SwapByteOrder(uint4* data) {
-    *data = (uint4){EndianSwap((*data).x),
-                    EndianSwap((*data).y),
-                    EndianSwap((*data).z),
-                    EndianSwap((*data).w)};
+    *data = (uint4){
+        EndianSwap((*data).x),
+        EndianSwap((*data).y),
+        EndianSwap((*data).z),
+        EndianSwap((*data).w)};
 }


### PR DESCRIPTION
Format previously missed files:
- src/Cuda/benchmarks.cpp
- src/Cuda/xpmclient.cpp
- src/Hip/benchmarks_hip.cpp
- src/Hip/xpmclient_hip.cpp
- src/OpenCL/sha256.h