### PR TITLE
feat(devenv): enable CUDA and HIP miner builds with improved driver detection

### DIFF
--- a/devenv.lock
+++ b/devenv.lock
@@ -3,10 +3,10 @@
     "devenv": {
       "locked": {
         "dir": "src/modules",
-        "lastModified": 1732896163,
+        "lastModified": 1767733209,
         "owner": "cachix",
         "repo": "devenv",
-        "rev": "2c928a199d56191d7a53f29ccafa56238c8ce4e5",
+        "rev": "32a795ac142f4578aa5f6ecc8eafb79d253d99ae",
         "type": "github"
       },
       "original": {
@@ -19,30 +19,51 @@
     "flake-compat": {
       "flake": false,
       "locked": {
-        "lastModified": 1732722421,
-        "owner": "edolstra",
+        "lastModified": 1767039857,
+        "owner": "NixOS",
         "repo": "flake-compat",
-        "rev": "9ed2ac151eada2306ca8c418ebd97807bb08f6ac",
+        "rev": "5edf11c44bc78a0d334f6334cdaf7d60d732daab",
         "type": "github"
       },
       "original": {
-        "owner": "edolstra",
+        "owner": "NixOS",
         "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "git-hooks": {
+      "inputs": {
+        "flake-compat": "flake-compat",
+        "gitignore": "gitignore",
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1767281941,
+        "owner": "cachix",
+        "repo": "git-hooks.nix",
+        "rev": "f0927703b7b1c8d97511c4116eb9b4ec6645a0fa",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cachix",
+        "repo": "git-hooks.nix",
         "type": "github"
       }
     },
     "gitignore": {
       "inputs": {
         "nixpkgs": [
-          "pre-commit-hooks",
+          "git-hooks",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1709087332,
+        "lastModified": 1762808025,
         "owner": "hercules-ci",
         "repo": "gitignore.nix",
-        "rev": "637db329424fd7e46cf4185293b9cc8c88c95394",
+        "rev": "cb5e3fdca1de58ccbc3ef53de65bd372b48f567c",
         "type": "github"
       },
       "original": {
@@ -53,10 +74,10 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1716977621,
+        "lastModified": 1767052823,
         "owner": "cachix",
         "repo": "devenv-nixpkgs",
-        "rev": "4267e705586473d3e5c8d50299e71503f16a6fb6",
+        "rev": "538a5124359f0b3d466e1160378c87887e3b51a4",
         "type": "github"
       },
       "original": {
@@ -66,48 +87,14 @@
         "type": "github"
       }
     },
-    "nixpkgs-stable": {
-      "locked": {
-        "lastModified": 1733220138,
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "bcb68885668cccec12276bbb379f8f2557aa06ce",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixos-24.05",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "pre-commit-hooks": {
-      "inputs": {
-        "flake-compat": "flake-compat",
-        "gitignore": "gitignore",
-        "nixpkgs": [
-          "nixpkgs"
-        ],
-        "nixpkgs-stable": "nixpkgs-stable"
-      },
-      "locked": {
-        "lastModified": 1732021966,
-        "owner": "cachix",
-        "repo": "pre-commit-hooks.nix",
-        "rev": "3308484d1a443fc5bc92012435d79e80458fe43c",
-        "type": "github"
-      },
-      "original": {
-        "owner": "cachix",
-        "repo": "pre-commit-hooks.nix",
-        "type": "github"
-      }
-    },
     "root": {
       "inputs": {
         "devenv": "devenv",
+        "git-hooks": "git-hooks",
         "nixpkgs": "nixpkgs",
-        "pre-commit-hooks": "pre-commit-hooks"
+        "pre-commit-hooks": [
+          "git-hooks"
+        ]
       }
     }
   },

--- a/devenv.nix
+++ b/devenv.nix
@@ -1,7 +1,6 @@
-{ pkgs, lib, ... }: {
-  languages.c.enable = true;
+{ pkgs, ... }: {
 
-  # Introduce all necessary build tools and dependencies
+  # 1. Install necessary packages
   packages = [
     pkgs.cmake
     pkgs.ceedling
@@ -9,39 +8,126 @@
     pkgs.curl
     pkgs.jansson
     pkgs.openssl
-    pkgs.gmp5
-    pkgs.gcc
+    pkgs.gmp
     pkgs.gnumake
+    pkgs.gcc
+    pkgs.cudaPackages.cudatoolkit
+    pkgs.rocmPackages.hipcc # ROCm/HIP compiler
+    pkgs.rocmPackages.clr   # ROCm Common Language Runtime
   ];
 
-  # Use mkForce to resolve shell definition conflicts
-  shell = lib.mkForce (pkgs.mkShell {
-    buildInputs = [
-      pkgs.cmake
-      pkgs.ceedling
-      pkgs.ncurses
-      pkgs.curl
-      pkgs.jansson
-      pkgs.openssl
-      pkgs.gmp5
-      pkgs.gcc
-      pkgs.gnumake
-    ];
+  env = {
+    # Ensure CMake uses GCC/G++ from Nix, not the system
+    CC = "gcc";
+    CXX = "g++";
+    CUDA_STUB_LIB = "${pkgs.cudaPackages.cudatoolkit}/lib/stubs/libcuda.so";
+    CUDA_PATH = "${pkgs.cudaPackages.cudatoolkit}";
+    HIP_ROOT_DIR = "${pkgs.rocmPackages.hipcc}";
+    ROCM_PATH = "${pkgs.rocmPackages.hipcc}";
+  };
 
-    # Commands executed when the shell starts
-    shellHook = ''
-      echo "Initializing cmake build in src directory..."
-      mkdir -p build
-      cd build
-      cmake -DCMAKE_BUILD_TYPE=Release -DBUILDOPENCLMINER=OFF -DBUILDCUDAMINER=OFF ../src
-      make
-      echo "Build complete. You can find the results in the 'build' directory."
-    '';
-  });
+  scripts.build-miner.exec = ''
+    echo "⚙️  Auto-configuring project (CUDA + HIP)..."
+    cmake -S src -B build \
+      -DCMAKE_BUILD_TYPE=Release \
+      -DBUILDCUDAMINER=ON \
+      -DBUILDHIPMINER=ON \
+      -DBUILDOPENCLMINER=OFF \
+      -DCUDA_DRIVER_LIBRARY=$CUDA_STUB_LIB \
+      -DHIP_ROOT_DIR=$HIP_ROOT_DIR
+    echo "🔨 Starting multi-core build..."
+    cmake --build build -j$(nproc)
+  '';
+
+  # Auto-detect CUDA drivers (NixOS/WSL2/Ubuntu)
+  scripts.detect-cuda-drivers.exec = ''
+    find_driver() {
+      local path="$1"
+      [ -d "$path" ] || return 1
+      local res=$(find "$path" -maxdepth 1 -name "libcuda.so.*" -print -quit 2>/dev/null)
+      [ -n "$res" ] || return 1
+      echo "$res"
+    }
+    
+    find_jit() {
+      local path="$1"
+      [ -d "$path" ] || return 1
+      find "$path" -maxdepth 1 -name "libnvidia-ptxjitcompiler.so.*" -print -quit 2>/dev/null
+    }
+
+    IS_WSL2=false
+    [ -f "/proc/sys/fs/binfmt_misc/WSLInterop" ] || grep -qi "microsoft" /proc/version 2>/dev/null && IS_WSL2=true
+    
+    IS_NIXOS=false
+    [ -f "/etc/nixos/configuration.nix" ] || [ -n "$NIX_PATH" ] || [ -d "/run/opengl-driver" ] && IS_NIXOS=true
+
+    FOUND_LIBCUDA=""
+    FOUND_JIT=""
+
+    # Priority: NixOS > WSL2 > Ubuntu > Fallback
+    if [ "$IS_NIXOS" = "true" ] && [ -d "/run/opengl-driver/lib" ]; then
+      res=$(find "/run/opengl-driver/lib" -maxdepth 1 \( -name "libcuda.so*" -type f -o -name "libcuda.so*" -type l \) 2>/dev/null | head -1)
+      [ -n "$res" ] && FOUND_LIBCUDA=$(readlink -f "$res" 2>/dev/null || echo "$res")
+      [ -n "$FOUND_LIBCUDA" ] && FOUND_JIT=$(find "/run/opengl-driver/lib" -maxdepth 1 \( -name "libnvidia-ptxjitcompiler.so*" -type f -o -name "libnvidia-ptxjitcompiler.so*" -type l \) 2>/dev/null | head -1)
+      [ -n "$FOUND_JIT" ] && FOUND_JIT=$(readlink -f "$FOUND_JIT" 2>/dev/null || echo "$FOUND_JIT")
+    fi
+
+    if [ -z "$FOUND_LIBCUDA" ] && [ "$IS_WSL2" = "true" ]; then
+      FOUND_LIBCUDA=$(find_driver "/usr/lib/wsl/lib")
+      [ -n "$FOUND_LIBCUDA" ] && FOUND_JIT=$(find_jit "/usr/lib/wsl/lib")
+      [ -z "$FOUND_LIBCUDA" ] && FOUND_LIBCUDA=$(find_driver "/usr/lib/x86_64-linux-gnu")
+      [ -n "$FOUND_LIBCUDA" ] && [ -z "$FOUND_JIT" ] && FOUND_JIT=$(find_jit "/usr/lib/x86_64-linux-gnu")
+    elif [ -z "$FOUND_LIBCUDA" ]; then
+      FOUND_LIBCUDA=$(find_driver "/usr/lib/x86_64-linux-gnu")
+      [ -n "$FOUND_LIBCUDA" ] && FOUND_JIT=$(find_jit "/usr/lib/x86_64-linux-gnu")
+      [ -z "$FOUND_LIBCUDA" ] && FOUND_LIBCUDA=$(find_driver "/usr/lib/wsl/lib")
+      [ -n "$FOUND_LIBCUDA" ] && [ -z "$FOUND_JIT" ] && FOUND_JIT=$(find_jit "/usr/lib/wsl/lib")
+    fi
+
+    [ -z "$FOUND_LIBCUDA" ] && FOUND_LIBCUDA=$(find_driver "/usr/lib64")
+    [ -n "$FOUND_LIBCUDA" ] && [ -z "$FOUND_JIT" ] && FOUND_JIT=$(find_jit "/usr/lib64")
+
+    [ -n "$FOUND_LIBCUDA" ] && {
+      [ -n "$FOUND_JIT" ] && echo "$FOUND_LIBCUDA $FOUND_JIT" || echo "$FOUND_LIBCUDA"
+    }
+  '';
+
+  enterShell = ''
+    echo "=========================================="
+    echo "🚀 xpmminer Development Environment"
+    echo "=========================================="
+
+    if [ -d "/run/opengl-driver/lib" ]; then
+      export LD_LIBRARY_PATH="/run/opengl-driver/lib:''${LD_LIBRARY_PATH:-}"
+      if [ -f "/run/opengl-driver/lib/libcuda.so.1" ] || [ -L "/run/opengl-driver/lib/libcuda.so.1" ]; then
+        export LD_PRELOAD="/run/opengl-driver/lib/libcuda.so.1:''${LD_PRELOAD:-}"
+        echo "✅ Using NixOS NVIDIA driver"
+      fi
+    else
+      PRELOAD=$(detect-cuda-drivers)
+      if [ -n "$PRELOAD" ]; then
+        export LD_PRELOAD="$PRELOAD"
+        FIRST_DRIVER=$(echo "$PRELOAD" | awk '{print $1}')
+        echo "✅ Found System Driver: $FIRST_DRIVER"
+        echo "$PRELOAD" | grep -q "libnvidia-ptxjitcompiler" && {
+          echo "✅ Found JIT Compiler : $(echo "$PRELOAD" | awk '{print $2}')"
+        }
+        echo "💉 Auto-injected system drivers via LD_PRELOAD"
+        [ -d "/usr/lib/wsl/lib" ] && export LD_LIBRARY_PATH="/usr/lib/wsl/lib:''${LD_LIBRARY_PATH:-}"
+      else
+        [ -f "/etc/nixos/configuration.nix" ] || [ -d "/run/opengl-driver" ] && {
+          echo "⚠️  Warning: Could not find NVIDIA drivers."
+          echo "    On NixOS, ensure hardware.nvidia is configured and run: sudo nixos-rebuild switch"
+        } || echo "ℹ️  Note: NVIDIA drivers not found (normal for AMD/CPU miner)"
+      fi
+    fi
+
+    export PATH="$CUDA_PATH/bin:$ROCM_PATH/bin:$PATH"
+
+    echo ""
+    echo "💡 Usage:"
+    echo " Run 'build-miner'  -> Auto-start compilation"
+  '';
 
   git-hooks.excludes = [ ".devenv" ];
-  git-hooks.hooks = {
-    clang-tidy.enable = true;
-  };
 }
-

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,4 +1,5 @@
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 3.5)
+project(xpmminer LANGUAGES C CXX)
 
 option(DEBUG_MINING_AMD_OPENCL "Print performance counters")
 option(BUILDCPUMINER "build CPU miner" ON)


### PR DESCRIPTION
- Refactor detect-cuda-drivers script with find_driver and find_jit helper functions
- Add NixOS environment detection and driver path support (/run/opengl-driver/lib)
- Optimize driver lookup priority: NixOS > WSL2 > Ubuntu > Fallback
- Simplify conditional syntax in enterShell
- Remove redundant comments for cleaner code
- Improve driver loading logic for NixOS environments